### PR TITLE
Correct OSIS abbreviation for Judges

### DIFF
--- a/CSV/Books.csv
+++ b/CSV/Books.csv
@@ -5,7 +5,7 @@
 "4","Numbers","36","Pentateuch","Nu","Num"
 "5","Deuteronomy","34","Pentateuch","Dt","Deu"
 "6","Joshua","24","Historical","Jos","Jos"
-"7","Judges","21","Historical","Jdg","Jud"
+"7","Judges","21","Historical","Jdg","Jdg"
 "8","Ruth","4","Historical","Ru","Rut"
 "9","1 Samuel","31","Historical","1Sa","1Sa"
 "10","2 Samuel","24","Historical","2Sa","2Sa"


### PR DESCRIPTION
In Books.csv the OSIS Name for Judges was Jud, which is actually for Jude. I've corrected it to Jdg.